### PR TITLE
isMobile() has moved under a 'device' key in aframe utils

### DIFF
--- a/docs/aframe-extras/src/controls/hmd-controls.js
+++ b/docs/aframe-extras/src/controls/hmd-controls.js
@@ -1,5 +1,5 @@
 var radToDeg = THREE.Math.radToDeg,
-    isMobile = AFRAME.utils.isMobile();
+    isMobile = (AFRAME.utils.isMobile || AFRAME.utils.device.isMobile)();
 
 module.exports = {
   schema: {


### PR DESCRIPTION
See https://github.com/aframevr/aframe/pull/2044 for more details.